### PR TITLE
feat(logging): integrate standard Python logging into db_tools_pkg

### DIFF
--- a/db_tools_pkg/tools.py
+++ b/db_tools_pkg/tools.py
@@ -45,7 +45,7 @@ def execute_command(sql_command: str, db_engine: Engine) -> bool:
                 f"✅ Admin command executed successfully: {sql_command[:50]}..."
             )
             return True
-    except SQLAlchemyError as e:
+    except SQLAlchemyError:
         logger.error(
             f"❌ An error occurred with the admin command: {sql_command[:50]}...",
             exc_info=True,
@@ -91,7 +91,7 @@ def run_sql(
                     # If an error occured within the transaction, roll it back
                     transaction.rollback()
                     raise  # Re-raise the exception to be called by outer block
-    except SQLAlchemyError as e:
+    except SQLAlchemyError:
         logger.error(
             f"❌ A database error occurred while executing: {sql[:50]}...",
             exc_info=True,

--- a/db_tools_pkg/tools.py
+++ b/db_tools_pkg/tools.py
@@ -5,12 +5,19 @@
 #
 # Finalized on: May 28, 2025
 
+import logging
 from typing import Dict, Optional, Tuple, Union
 
 import pandas as pd
 from sqlalchemy import Engine, text
 from sqlalchemy.exc import SQLAlchemyError
 
+
+logger = logging.getLogger(__name__)
+# The following is BEST PRACTISE for libraries
+# It prevents "No handler found" warnings if the importing application hasn't
+# configured logging. The application's configuration will override this.
+logger.addHandler(logging.NullHandler())
 
 # Custom class for type hints
 ParamsType = Optional[Union[Tuple, Dict]]
@@ -31,11 +38,18 @@ def execute_command(sql_command: str, db_engine: Engine) -> bool:
             # For DDL/DCL commands, we often need to wrap them in a transaction
             # and commit them to ensure they take effect immediately.
             with connection.begin() as transaction:
+                logger.debug(f"👑 Executing admin command: '{sql_command[:100]}'...")
                 connection.execute(text(sql_command))
                 transaction.commit()
+            logger.info(
+                f"✅ Admin command executed successfully: {sql_command[:50]}..."
+            )
             return True
     except SQLAlchemyError as e:
-        print(f"❌ An error occured with the admin command: {e}")
+        logger.error(
+            f"❌ An error occurred with the admin command: {sql_command[:50]}...",
+            exc_info=True,
+        )
         return False
 
 
@@ -56,23 +70,32 @@ def run_sql(
     try:
         with engine.connect() as connection:
             with connection.begin() as transaction:
+                logger.debug(f"▶️ Executing SQL: {sql[:100]}... with params: {params}")
                 try:
                     result = connection.execute(text(sql), params)
 
                     if result.returns_rows:
                         # It's a SELECT query. Return results as a DataFrame
-                        return pd.DataFrame(result.mappings().all())
+                        df = pd.DataFrame(result.mappings().all())
+                        logger.info(f"✅ SELECT query returned {len(df)} rows.")
+                        return df
                     else:
                         # It's an INSERT/UPDATE/DELET.
                         # Commit and return the number of affected rows
                         transaction.commit()
+                        logger.info(
+                            f"✅ Non-query command affected {result.rowcount} rows."
+                        )
                         return result.rowcount
                 except:
                     # If an error occured within the transaction, roll it back
                     transaction.rollback()
                     raise  # Re-raise the exception to be called by outer block
     except SQLAlchemyError as e:
-        print(f"❌ A database error occured: {e}")
+        logger.error(
+            f"❌ A database error occurred while executing: {sql[:50]}...",
+            exc_info=True,
+        )
         return None
 
 
@@ -83,7 +106,7 @@ def create_read_only_user(
     Safely creates a new user with read-only privileges on a specific database.
     This demonstrates the correct use of the execute_command tool.
     """
-    print(f"🥚 Attempting to create read-only user: {username}...")
+    logger.info(f"🌱 Attempting to create read-only user: {username}...")
 
     # These DDL/DCL commands cannot be parameterized, so we use execute_command
     # after building the strings from the trusted inputs
@@ -92,16 +115,16 @@ def create_read_only_user(
     cmd_select = f"GRANT SELECT ON '{database}'.* TO '{username}'@'%';"
 
     if not execute_command(cmd_create, db_engine):
-        print(f"❌ Failed at CREATE USER step for {username}")
+        logger.error(f"❌ Failed at CREATE USER step for {username}")
         return False
 
     if not execute_command(cmd_usage, db_engine):
-        print(f"❌ Failed at GRANT USAGE step for {username}")
+        logger.error(f"❌ Failed at GRANT USAGE step for {username}")
         return False
 
     if not execute_command(cmd_select, db_engine):
-        print(f"❌ Failed at GRANT SELECT step for {username}")
+        logger.error(f"❌ Failed at GRANT SELECT step for {username}")
         return False
 
-    print(f"✅ Successfully created user '{username}'.")
+    logger.info(f"➕ Successfully created user '{username}'.")
     return True


### PR DESCRIPTION
### Description

This PR refactors `db_tools_pkg/tools.py` to replace all `print()` statements with the standard Python `logging` module. A module-level logger (`logging.getLogger(__name__)`) is now used.

### Reason for Change

-   **Professionalism:** Moves away from `print()` for more structured and controllable output.
-   **Flexibility for Consumers:** Allows applications using this package to define their own logging handlers, formatters, and levels without interference.
-   **Library Best Practice:** Includes a `NullHandler` by default to prevent "No handler found" warnings if the consuming application doesn't explicitly configure logging for this package.

### Changes Made

-   Added `import logging`.
-   Initialized `logger = logging.getLogger(__name__)`.
-   Added `logger.addHandler(logging.NullHandler())`.
-   Replaced all `print()` calls in `execute_command`, `run_sql`, and `create_read_only_user` with appropriate `logger.debug()`, `logger.info()`, or `logger.error(exc_info=True)` calls.